### PR TITLE
Inkscape 1.0 Interface: --export-file should be --export-filename

### DIFF
--- a/svg_reader.py
+++ b/svg_reader.py
@@ -679,12 +679,12 @@ class SVG_READER(inkex.Effect):
                 (stdout,stderr)=run_external(cmd, self.timout)
                 if stdout.find(b'Inkscape 1.')==-1:
                     cmd = [ self.inkscape_exe, self.png_area, "--export-dpi", dpi, \
-                            "--export-background","rgb(255, 255, 255)","--export-background-opacity", \
+                            "--export-background","rgb(255,255,255)","--export-background-opacity", \
                             "255" ,"--export-png", png_temp_file, svg_temp_file ]
                 else:
                     cmd = [ self.inkscape_exe, self.png_area, "--export-dpi", dpi, \
-                            "--export-background","rgb(255, 255, 255)","--export-background-opacity", \
-                            "255" ,"--export-type=png", "--export-file", png_temp_file, svg_temp_file ]
+                            "--export-background","rgb(255,255,255)","--export-background-opacity", \
+                            "255" ,"--export-type", "png", "--export-filename", png_temp_file, svg_temp_file ]
 
                 run_external(cmd, self.timout)
                 self.raster_PIL = Image.open(png_temp_file)


### PR DESCRIPTION
Resolves #10, see @erneztox's screenshot.

Error occurs during export to PNG. If Inkscape throws an error, the PNG file is never made and K40-Whisperer shows the error dialog in #10.
The fix was to replace --export-file with --export-filename.
Also, for some reason the spaces needed to be removed from the rgb string of the --export-background option. So `rgb(255,255,255)` is valid but `rgb(255, 255, 255)` causes Inkscape to return the following:
```
ConcreteInkscapeApplication<Gtk::Application>::on_open: Can't use '--export-filename' 
with multiple input files (output file would be overwritten for each input file).
Please use '--export-type' instead and rename manually.
``` 

As if the spaces confuse Inkscape into thinking multiple input files were supplied. Simply removing the spaces works, and so does using a hex color string like `#ffffff`.